### PR TITLE
Feature/signup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,8 @@ dependencies {
 	testImplementation 'org.springframework.security:spring-security-test'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 	/* JWT */
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.1'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.1'

--- a/src/main/java/Idea/Archieve/IdeaArchieve/IdeaArchiveApplication.java
+++ b/src/main/java/Idea/Archieve/IdeaArchieve/IdeaArchiveApplication.java
@@ -2,13 +2,13 @@ package Idea.Archieve.IdeaArchieve;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
-@SpringBootApplication(exclude = {SecurityAutoConfiguration.class })
+@SpringBootApplication
 @EnableCaching
 @EnableConfigurationProperties
 @ConfigurationPropertiesScan

--- a/src/main/java/Idea/Archieve/IdeaArchieve/domain/auth/entity/RefreshToken.java
+++ b/src/main/java/Idea/Archieve/IdeaArchieve/domain/auth/entity/RefreshToken.java
@@ -1,0 +1,29 @@
+package Idea.Archieve.IdeaArchieve.domain.auth.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+import org.springframework.data.redis.core.index.Indexed;
+
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+@RedisHash(value = "refreshToken")
+public class RefreshToken {
+
+    @Id
+    private String email;
+
+    @Indexed
+    private String token;
+
+    @TimeToLive
+    private long expiredAt;
+
+}

--- a/src/main/java/Idea/Archieve/IdeaArchieve/domain/auth/exception/ExistEmailException.java
+++ b/src/main/java/Idea/Archieve/IdeaArchieve/domain/auth/exception/ExistEmailException.java
@@ -1,0 +1,15 @@
+package Idea.Archieve.IdeaArchieve.domain.auth.exception;
+
+import Idea.Archieve.IdeaArchieve.global.exception.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class ExistEmailException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public ExistEmailException(String message) {
+        super(message);
+        this.errorCode = ErrorCode.ALREADY_EXIST_EMAIL;
+    }
+}

--- a/src/main/java/Idea/Archieve/IdeaArchieve/domain/auth/presentation/AuthController.java
+++ b/src/main/java/Idea/Archieve/IdeaArchieve/domain/auth/presentation/AuthController.java
@@ -1,0 +1,27 @@
+package Idea.Archieve.IdeaArchieve.domain.auth.presentation;
+
+import Idea.Archieve.IdeaArchieve.domain.auth.presentation.dto.request.MemberSignUpRequest;
+import Idea.Archieve.IdeaArchieve.domain.auth.service.MemberSignUpService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class AuthController {
+
+    private final MemberSignUpService memberSignUpService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<Void> signUp(@RequestBody @Valid MemberSignUpRequest memberSignUpRequest) {
+        memberSignUpService.execute(memberSignUpRequest);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+}

--- a/src/main/java/Idea/Archieve/IdeaArchieve/domain/auth/presentation/dto/request/MemberSignUpRequest.java
+++ b/src/main/java/Idea/Archieve/IdeaArchieve/domain/auth/presentation/dto/request/MemberSignUpRequest.java
@@ -1,0 +1,27 @@
+package Idea.Archieve.IdeaArchieve.domain.auth.presentation.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberSignUpRequest {
+
+    @NotBlank(message = "이메일은 공백을 허용하지 않습니다.")
+    private String email;
+
+    @NotBlank(message = "비밀번호는 공백을 허용하지 않습니다.")
+    @Pattern(regexp = "(?=.*\\W)(?=\\S+$).{8,16}", message = "비밀번호는 특수문자가 1개 이상 포함되어야 하고 글자 수는 8 ~ 16자 사이여야 합니다.")
+    private String password;
+
+    @NotBlank(message = "이름은 공백을 허용하지 않습니다.")
+    private String name;
+
+    @NotBlank(message = "역할은 공백을 허용하지 않습니다.")
+    private String role;
+}

--- a/src/main/java/Idea/Archieve/IdeaArchieve/domain/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/Idea/Archieve/IdeaArchieve/domain/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,7 @@
+package Idea.Archieve.IdeaArchieve.domain.auth.repository;
+
+import Idea.Archieve.IdeaArchieve.domain.auth.entity.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, String> {
+}

--- a/src/main/java/Idea/Archieve/IdeaArchieve/domain/auth/service/MemberSignUpService.java
+++ b/src/main/java/Idea/Archieve/IdeaArchieve/domain/auth/service/MemberSignUpService.java
@@ -1,0 +1,20 @@
+package Idea.Archieve.IdeaArchieve.domain.auth.service;
+
+import Idea.Archieve.IdeaArchieve.domain.auth.presentation.dto.request.MemberSignUpRequest;
+import Idea.Archieve.IdeaArchieve.domain.auth.repository.RefreshTokenRepository;
+import Idea.Archieve.IdeaArchieve.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberSignUpService {
+
+    private final PasswordEncoder passwordEncoder;
+    private final MemberRepository memberRepository;
+
+    public void execute(MemberSignUpRequest memberSignUpRequest) {
+
+    }
+}

--- a/src/main/java/Idea/Archieve/IdeaArchieve/domain/auth/service/MemberSignUpService.java
+++ b/src/main/java/Idea/Archieve/IdeaArchieve/domain/auth/service/MemberSignUpService.java
@@ -3,6 +3,9 @@ package Idea.Archieve.IdeaArchieve.domain.auth.service;
 import Idea.Archieve.IdeaArchieve.domain.auth.exception.ExistEmailException;
 import Idea.Archieve.IdeaArchieve.domain.auth.presentation.dto.request.MemberSignUpRequest;
 import Idea.Archieve.IdeaArchieve.domain.auth.repository.RefreshTokenRepository;
+import Idea.Archieve.IdeaArchieve.domain.email.entity.EmailAuth;
+import Idea.Archieve.IdeaArchieve.domain.email.exception.NotVerifyEmailException;
+import Idea.Archieve.IdeaArchieve.domain.email.repository.EmailAuthRepository;
 import Idea.Archieve.IdeaArchieve.domain.member.Entity.Member;
 import Idea.Archieve.IdeaArchieve.domain.member.repository.MemberRepository;
 import Idea.Archieve.IdeaArchieve.global.filter.role.Role;
@@ -16,11 +19,19 @@ public class MemberSignUpService {
 
     private final PasswordEncoder passwordEncoder;
     private final MemberRepository memberRepository;
+    private final EmailAuthRepository emailAuthRepository;
 
     public void execute(MemberSignUpRequest memberSignUpRequest) {
 
         if(memberRepository.existsByEmail(memberSignUpRequest.getEmail())){
             throw new ExistEmailException("이미 존재하는 이메일입니다.");
+        }
+
+        EmailAuth emailAuth = emailAuthRepository.findById(memberSignUpRequest.getEmail())
+                .orElseThrow(() -> new NotVerifyEmailException("인증되지 않은 이메일입니다."));
+
+        if (!emailAuth.getAuthentication()) {
+            throw new NotVerifyEmailException("인증되지 않은 이메일입니다.");
         }
 
         Member member = Member

--- a/src/main/java/Idea/Archieve/IdeaArchieve/domain/auth/service/MemberSignUpService.java
+++ b/src/main/java/Idea/Archieve/IdeaArchieve/domain/auth/service/MemberSignUpService.java
@@ -2,7 +2,6 @@ package Idea.Archieve.IdeaArchieve.domain.auth.service;
 
 import Idea.Archieve.IdeaArchieve.domain.auth.exception.ExistEmailException;
 import Idea.Archieve.IdeaArchieve.domain.auth.presentation.dto.request.MemberSignUpRequest;
-import Idea.Archieve.IdeaArchieve.domain.auth.repository.RefreshTokenRepository;
 import Idea.Archieve.IdeaArchieve.domain.email.entity.EmailAuth;
 import Idea.Archieve.IdeaArchieve.domain.email.exception.NotVerifyEmailException;
 import Idea.Archieve.IdeaArchieve.domain.email.repository.EmailAuthRepository;

--- a/src/main/java/Idea/Archieve/IdeaArchieve/domain/auth/service/MemberSignUpService.java
+++ b/src/main/java/Idea/Archieve/IdeaArchieve/domain/auth/service/MemberSignUpService.java
@@ -1,8 +1,11 @@
 package Idea.Archieve.IdeaArchieve.domain.auth.service;
 
+import Idea.Archieve.IdeaArchieve.domain.auth.exception.ExistEmailException;
 import Idea.Archieve.IdeaArchieve.domain.auth.presentation.dto.request.MemberSignUpRequest;
 import Idea.Archieve.IdeaArchieve.domain.auth.repository.RefreshTokenRepository;
+import Idea.Archieve.IdeaArchieve.domain.member.Entity.Member;
 import Idea.Archieve.IdeaArchieve.domain.member.repository.MemberRepository;
+import Idea.Archieve.IdeaArchieve.global.filter.role.Role;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -16,5 +19,18 @@ public class MemberSignUpService {
 
     public void execute(MemberSignUpRequest memberSignUpRequest) {
 
+        if(memberRepository.existsByEmail(memberSignUpRequest.getEmail())){
+            throw new ExistEmailException("이미 존재하는 이메일입니다.");
+        }
+
+        Member member = Member
+                .builder()
+                .email(memberSignUpRequest.getEmail())
+                .password(passwordEncoder.encode(memberSignUpRequest.getPassword()))
+                .name(memberSignUpRequest.getName())
+                .role(Role.from(memberSignUpRequest.getRole()))
+                .build();
+
+        memberRepository.save(member);
     }
 }

--- a/src/main/java/Idea/Archieve/IdeaArchieve/domain/email/entity/EmailAuth.java
+++ b/src/main/java/Idea/Archieve/IdeaArchieve/domain/email/entity/EmailAuth.java
@@ -1,0 +1,29 @@
+package Idea.Archieve.IdeaArchieve.domain.email.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.validator.constraints.Length;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@RedisHash(value = "emailAuth", timeToLive = 60 * 15)
+public class EmailAuth {
+
+    @Id
+    private String email;
+
+    @Length(max = 4)
+    private String randomValue;
+
+    private Boolean authentication;
+
+    @ColumnDefault("1")
+    private Integer attemptCount;
+}

--- a/src/main/java/Idea/Archieve/IdeaArchieve/domain/email/exception/NotVerifyEmailException.java
+++ b/src/main/java/Idea/Archieve/IdeaArchieve/domain/email/exception/NotVerifyEmailException.java
@@ -1,0 +1,15 @@
+package Idea.Archieve.IdeaArchieve.domain.email.exception;
+
+import Idea.Archieve.IdeaArchieve.global.exception.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class NotVerifyEmailException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public NotVerifyEmailException(String message) {
+        super(message);
+        this.errorCode = ErrorCode.NOT_VERIFY_EMAIL;
+    }
+}

--- a/src/main/java/Idea/Archieve/IdeaArchieve/domain/email/repository/EmailAuthRepository.java
+++ b/src/main/java/Idea/Archieve/IdeaArchieve/domain/email/repository/EmailAuthRepository.java
@@ -1,0 +1,7 @@
+package Idea.Archieve.IdeaArchieve.domain.email.repository;
+
+import Idea.Archieve.IdeaArchieve.domain.email.entity.EmailAuth;
+import org.springframework.data.repository.CrudRepository;
+
+public interface EmailAuthRepository extends CrudRepository<EmailAuth, String> {
+}

--- a/src/main/java/Idea/Archieve/IdeaArchieve/domain/member/repository/MemberRepository.java
+++ b/src/main/java/Idea/Archieve/IdeaArchieve/domain/member/repository/MemberRepository.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/Idea/Archieve/IdeaArchieve/domain/post/service/PostService.java
+++ b/src/main/java/Idea/Archieve/IdeaArchieve/domain/post/service/PostService.java
@@ -2,13 +2,11 @@ package Idea.Archieve.IdeaArchieve.domain.post.service;
 
 import Idea.Archieve.IdeaArchieve.domain.post.Entity.Post;
 import Idea.Archieve.IdeaArchieve.domain.post.exception.NotExistPostException;
-import Idea.Archieve.IdeaArchieve.domain.post.presentation.dto.request.UpdatePost;
 import Idea.Archieve.IdeaArchieve.domain.post.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/Idea/Archieve/IdeaArchieve/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/Idea/Archieve/IdeaArchieve/global/exception/handler/GlobalExceptionHandler.java
@@ -1,7 +1,10 @@
 package Idea.Archieve.IdeaArchieve.global.exception.handler;
 
+import Idea.Archieve.IdeaArchieve.domain.auth.exception.ExistEmailException;
+import Idea.Archieve.IdeaArchieve.domain.email.exception.NotVerifyEmailException;
 import Idea.Archieve.IdeaArchieve.domain.member.exception.MemberNotFoundException;
 import Idea.Archieve.IdeaArchieve.domain.post.exception.NotExistPostException;
+import Idea.Archieve.IdeaArchieve.domain.post.exception.NotVerifyMember;
 import Idea.Archieve.IdeaArchieve.global.exception.ErrorMessage;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -24,6 +27,27 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(MemberNotFoundException.class)
     public ResponseEntity<ErrorMessage> handleMemberNotFoundException(HttpServletRequest request , MemberNotFoundException exception) {
+        printError(request, exception, exception.getErrorCode().getMessage());
+        ErrorMessage errorMessage = new ErrorMessage(exception.getErrorCode().getMessage(), exception.getErrorCode().getStatus());
+        return new ResponseEntity<>(errorMessage, HttpStatus.valueOf(exception.getErrorCode().getStatus()));
+    }
+
+    @ExceptionHandler(NotVerifyEmailException.class)
+    public ResponseEntity<ErrorMessage> handleNotVerifyEmailException(HttpServletRequest request , NotVerifyEmailException exception) {
+        printError(request, exception, exception.getErrorCode().getMessage());
+        ErrorMessage errorMessage = new ErrorMessage(exception.getErrorCode().getMessage(), exception.getErrorCode().getStatus());
+        return new ResponseEntity<>(errorMessage, HttpStatus.valueOf(exception.getErrorCode().getStatus()));
+    }
+
+    @ExceptionHandler(ExistEmailException.class)
+    public ResponseEntity<ErrorMessage> handleExistEmailException(HttpServletRequest request , ExistEmailException exception) {
+        printError(request, exception, exception.getErrorCode().getMessage());
+        ErrorMessage errorMessage = new ErrorMessage(exception.getErrorCode().getMessage(), exception.getErrorCode().getStatus());
+        return new ResponseEntity<>(errorMessage, HttpStatus.valueOf(exception.getErrorCode().getStatus()));
+    }
+
+    @ExceptionHandler(NotVerifyMember.class)
+    public ResponseEntity<ErrorMessage> handleNotVerifyMember(HttpServletRequest request , NotVerifyMember exception) {
         printError(request, exception, exception.getErrorCode().getMessage());
         ErrorMessage errorMessage = new ErrorMessage(exception.getErrorCode().getMessage(), exception.getErrorCode().getStatus());
         return new ResponseEntity<>(errorMessage, HttpStatus.valueOf(exception.getErrorCode().getStatus()));


### PR DESCRIPTION
## 개요 💡
회원가입 로직입니다.

## 작업 내용 💻
이메일, 비밀번호, 이름, 역할을 받아 회원가입 하는 로직입니다.
역할은 저희가 ADMIN 계정을 따로 만들고 프론트에서 무조건 MEMBER로 보내게 할 예정입니다.
이메일이 이미 존재하거나, 인증되지 않은 이메일로 회원가입을 하지 못하도록 예외 처리했습니다.


## 리뷰해주세요 🙏
회원가입을 할 경우에 넘겨줘야할 필드가 있으면 리뷰 해주시면 감사하겠습니다.