### PR TITLE
:bug: member_id로 객체를 삭제 시키지 않고 member라는 객체로 받아서 객체를 삭제시키도록 수정 , findB…

### DIFF
--- a/src/main/java/Idea/Archive/IdeaArchive/domain/member/presentation/MemberController.java
+++ b/src/main/java/Idea/Archive/IdeaArchive/domain/member/presentation/MemberController.java
@@ -2,6 +2,7 @@ package Idea.Archive.IdeaArchive.domain.member.presentation;
 
 
 import Idea.Archive.IdeaArchive.domain.member.presentation.dto.request.ChangePasswordRequest;
+import Idea.Archive.IdeaArchive.domain.member.presentation.dto.request.WithdrawMemberRequest;
 import Idea.Archive.IdeaArchive.domain.member.presentation.dto.response.MyPageResponse;
 import Idea.Archive.IdeaArchive.domain.member.service.*;
 import Idea.Archive.IdeaArchive.domain.member.presentation.dto.request.ChangeNameRequest;
@@ -37,8 +38,8 @@ public class MemberController {
     }
 
     @DeleteMapping
-    public ResponseEntity<Void> withdraw(@RequestParam String email, @RequestParam String password) {
-        withdrawService.execute(email,password);
+    public ResponseEntity<Void> withdraw(@RequestBody @Valid WithdrawMemberRequest withdrawMemberRequest) {
+        withdrawService.execute(withdrawMemberRequest);
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/Idea/Archive/IdeaArchive/domain/member/presentation/dto/request/WithdrawMemberRequest.java
+++ b/src/main/java/Idea/Archive/IdeaArchive/domain/member/presentation/dto/request/WithdrawMemberRequest.java
@@ -1,0 +1,16 @@
+package Idea.Archive.IdeaArchive.domain.member.presentation.dto.request;
+
+
+import lombok.Getter;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+public class WithdrawMemberRequest {
+
+    @NotBlank
+    private String email;
+
+    @NotBlank
+    private String password;
+}

--- a/src/main/java/Idea/Archive/IdeaArchive/domain/member/service/MyPageService.java
+++ b/src/main/java/Idea/Archive/IdeaArchive/domain/member/service/MyPageService.java
@@ -29,14 +29,8 @@ public class MyPageService {
         Member member = memberRepository.findByEmail(currentMember.getEmail())
                 .orElseThrow(() -> new MemberNotFoundException("존재하지 않는 회원입니다"));
         List<ViewPostResponse> heartList = ViewPostResponse.convertToHeartList(member.getHearts());
-        if (heartList.isEmpty()) {
-            throw new NotExistPostException("게시글이 존재하지 않습니다");
-        }
         List<Post> posts = postRepository.findByMember(member);
         List<ViewPostResponse> myPostList = ViewPostResponse.convertToPostList(posts);
-        if (myPostList.isEmpty()) {
-            throw new NotExistPostException("게시글이 존재하지 않습니다.");
-        }
         return MyPageResponse.builder()
                 .email(member.getEmail())
                 .name(member.getName())

--- a/src/main/java/Idea/Archive/IdeaArchive/domain/member/service/WithdrawService.java
+++ b/src/main/java/Idea/Archive/IdeaArchive/domain/member/service/WithdrawService.java
@@ -6,6 +6,7 @@ import Idea.Archive.IdeaArchive.domain.auth.repository.RefreshTokenRepository;
 import Idea.Archive.IdeaArchive.domain.member.entity.Member;
 import Idea.Archive.IdeaArchive.domain.member.exception.MemberNotFoundException;
 import Idea.Archive.IdeaArchive.domain.member.exception.MisMatchPasswordException;
+import Idea.Archive.IdeaArchive.domain.member.presentation.dto.request.WithdrawMemberRequest;
 import Idea.Archive.IdeaArchive.domain.member.repository.MemberRepository;
 import Idea.Archive.IdeaArchive.domain.post.entity.Heart;
 import Idea.Archive.IdeaArchive.domain.post.repository.HeartRepository;
@@ -28,13 +29,13 @@ public class WithdrawService {
     private final PostRepository postRepository;
 
     @Transactional(rollbackFor = Exception.class)
-    public void execute(String email,String password) {
-        Member member = memberRepository.findByEmail(email)
+    public void execute(WithdrawMemberRequest withdrawMemberRequest) {
+        Member member = memberRepository.findByEmail(withdrawMemberRequest.getEmail())
                 .orElseThrow(() -> new MemberNotFoundException("유저가 존재하지 않습니다"));
         RefreshToken refreshToken = refreshTokenRepository.findById(member.getEmail())
                 .orElseThrow(() -> new RefreshTokenNotFoundException("존재하지 않은 리프레시 토큰입니다."));
 
-        if (!passwordEncoder.matches(password, member.getPassword())) {
+        if (!passwordEncoder.matches(withdrawMemberRequest.getPassword(), member.getPassword())) {
             throw new MisMatchPasswordException("비밀번호가 일치하지 않습니다.");
         }
 
@@ -42,8 +43,8 @@ public class WithdrawService {
         for (int i = 0; i < hearts.size(); i++) {
             hearts.get(i).getPost().updateHeart(hearts.get(i).getPost().getHeartCount() - 1);
         }
-        heartRepository.deleteByMember_MemberId(member.getMemberId());
-        postRepository.deleteByMember_MemberId(member.getMemberId());
+        heartRepository.deleteByMember(member);
+        postRepository.deleteByMember(member);
         memberRepository.delete(member);
         refreshTokenRepository.delete(refreshToken);
     }

--- a/src/main/java/Idea/Archive/IdeaArchive/domain/post/repository/HeartRepository.java
+++ b/src/main/java/Idea/Archive/IdeaArchive/domain/post/repository/HeartRepository.java
@@ -12,6 +12,6 @@ public interface HeartRepository extends JpaRepository<Heart, Long> {
     boolean existsHeartByMemberAndPost(Member member , Post post);
     void deleteHeartByMemberAndPost(Member member, Post post);
     void deleteByPost(Post post);
-    void deleteByMember_MemberId(Long memberId);
+    void deleteByMember(Member member);
     List<Heart> findByMember_MemberId(Long memberId);
 }

--- a/src/main/java/Idea/Archive/IdeaArchive/domain/post/repository/PostRepository.java
+++ b/src/main/java/Idea/Archive/IdeaArchive/domain/post/repository/PostRepository.java
@@ -13,8 +13,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     List<Post> findByTitleContaining(@Param("keyword") String keyword);
     @Query("SELECT p FROM Post p JOIN p.category c WHERE c IN (:category) GROUP BY p HAVING COUNT(DISTINCT c) = :numCategory")
-    List<Post> findByAllCategories(@Param("category") List<Category> category, @Param("numCategory") int numCategory);
-    void deleteByMember_MemberId(Long memberId);
+    List<Post> findByAllCategories(@Param("category") List<Category> category, @Param("numCategory") long numCategory);
+    void deleteByMember(Member member);
     @Query("SELECT p FROM Post p ORDER BY p.heartCount + p.views DESC")
     List<Post> findAllOrderByHeartCountPlusViesDesc();
     List<Post> findByMember(Member member);


### PR DESCRIPTION
…yAlCategories 카테고리 수를 입력받을때 int -> long으로 변경

## 개요 💡
에러 수정

## 작업 내용 💻
1. member_id로 객체를 삭제 시키지 않고 member라는 객체로 받아서 객체를 삭제시키도록 수정 
2. 쿼리메서드 매개변수 타입을 int -> long으로 변경 3
3. 회원탈퇴시 요청을 param -> body로 변경

## 리뷰해주세요 🙏
또 에러가 나는지 확인해주세요
